### PR TITLE
Update local settings example to use environment variables

### DIFF
--- a/scripts/setup-local-dev.sh
+++ b/scripts/setup-local-dev.sh
@@ -96,7 +96,7 @@ echo "Local dev environment setup complete!"
 if [ $TABLES_CREATED -eq ${#TABLES[@]} ]; then
     echo "✅ All Azure Tables initialized successfully."
 else
-    echo "⚠️  Some Azure Tables may not have been initialized."
+    echo "⚠ Some Azure Tables may not have been initialized."
     echo "   Tables will be created automatically on first run."
 fi
 echo ""

--- a/src/CheckinBlaze.Functions/CheckinBlaze.Functions.csproj
+++ b/src/CheckinBlaze.Functions/CheckinBlaze.Functions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>

--- a/src/CheckinBlaze.Functions/local.settings.json.example
+++ b/src/CheckinBlaze.Functions/local.settings.json.example
@@ -1,0 +1,11 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "AzureTableStorageConnection": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "AzureAd:TenantId": "%AZURE_AD_TENANT_ID%",
+    "AzureAd:ClientId": "%AZURE_AD_CLIENT_ID%",
+    "AllowedOrigins": "https://localhost:5001"
+  }
+}


### PR DESCRIPTION
## Summary
- use environment variable placeholders in `local.settings.json.example`

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*